### PR TITLE
Select movie quality based on display capabilities.

### DIFF
--- a/src/app/lib/views/movie_detail.js
+++ b/src/app/lib/views/movie_detail.js
@@ -68,7 +68,7 @@
                 this.model.set('quality', 'HDRip');
             }
 
-            if (Settings.movies_default_quality === '720p' && torrents['720p'] !== undefined && document.getElementsByName('switch')[0] !== undefined) {
+            if ((Settings.movies_default_quality === '720p' || (ScreenResolution.HD || ScreenResolution.SD)) && torrents['720p'] !== undefined && document.getElementsByName('switch')[0] !== undefined) {
                 document.getElementsByName('switch')[0].checked = true;
             }
 


### PR DESCRIPTION
When using a <=720p display, movie source is automatically set to 720p despite the default resolution setting.
Useful when you decide to play something on a secondary display that's not FullHD.